### PR TITLE
Fix Activiti dependency resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://artifacts.alfresco.com/nexus/content/groups/public' }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- add Alfresco repository to build.gradle

## Testing
- `gradle test` *(fails: Could not resolve org.activiti:activiti-spring-boot-starter:8.2.0-alpha.21, network access required)*