### PR TITLE
Fix boot run with simple security

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ $ ./gradlew bootRun
 ```
 
 起動すると `helloUser` プロセスが自動的に開始し、コンソールにタスク完了メッセージが表示されます。
+サンプルでは簡易的なユーザーとして `user/password` を登録しています。
+Activiti 8 は Spring Security を利用するため、必要に応じて `SecurityConfig` クラスでユーザーを追加・変更してください。
 
 
 ### 実行方法

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.activiti:activiti-spring-boot-starter:8.2.0-alpha.21'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/example/SecurityConfig.java
+++ b/src/main/java/com/example/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+        manager.createUser(User.withUsername("user")
+                .password("{noop}password")
+                .roles("USER")
+                .build());
+        return manager;
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal `SecurityConfig` so Spring Security has a `UserDetailsService`
- include Spring Security starter
- update README with default credentials

## Testing
- `gradle test` *(fails: Plugin not found because build plugins cannot be downloaded)*