### PR TITLE
Load BPMN from external file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ JAR を生成して実行する場合は次の通りです。
 java -jar build/libs/activiti-demo-0.0.1-SNAPSHOT.jar
 ```
 
+### 🔄 BPMN を動的にリロードする
+
+`/workflow/reload` エンドポイントでは `workflow.bpmn-path` プロパティで指定された
+外部 BPMN ファイルを読み込みます。デフォルト値は
+`src/main/resources/processes/hello-user.bpmn20.xml` です。ファイルを編集してから
+再度 `/workflow/reload` を呼び出すと変更が反映されます。
+
 ### 🗂️ ディレクトリ構成
 
 ```

--- a/src/main/java/com/example/WorkflowService.java
+++ b/src/main/java/com/example/WorkflowService.java
@@ -4,6 +4,7 @@ import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.repository.Deployment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,16 +18,19 @@ public class WorkflowService {
     private final RuntimeService runtimeService;
     private final TaskService taskService;
     private final RepositoryService repositoryService;
+    private final String bpmnPath;
 
     /**
      * 各種 Activiti サービスを注入します。
      */
     public WorkflowService(RuntimeService runtimeService,
                            TaskService taskService,
-                           RepositoryService repositoryService) {
+                           RepositoryService repositoryService,
+                           @Value("${workflow.bpmn-path:src/main/resources/processes/hello-user.bpmn20.xml}") String bpmnPath) {
         this.runtimeService = runtimeService;
         this.taskService = taskService;
         this.repositoryService = repositoryService;
+        this.bpmnPath = bpmnPath;
     }
 
     /**
@@ -82,16 +86,21 @@ public class WorkflowService {
     public String runWithDynamicDeployment() {
         authenticate();
         System.out.println("Starting process: dynamic deployment");
-        Deployment deployment = repositoryService.createDeployment()
-                .addClasspathResource("processes/hello-user.bpmn20.xml")
-                .deploy();
+        try (java.io.InputStream in = new java.io.FileInputStream(bpmnPath)) {
+            Deployment deployment = repositoryService.createDeployment()
+                    .addInputStream("hello-user.bpmn20.xml", in)
+                    .deploy();
 
-        runtimeService.startProcessInstanceByKey("helloUser");
-        completeTasks();
+            runtimeService.startProcessInstanceByKey("helloUser");
+            completeTasks();
 
-        repositoryService.deleteDeployment(deployment.getId(), true);
-        SecurityContextHolder.clearContext();
-        return "Process completed: dynamic deployment";
+            repositoryService.deleteDeployment(deployment.getId(), true);
+            return "Process completed: dynamic deployment";
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to load BPMN file: " + bpmnPath, e);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,6 @@ spring:
   # Uncomment to use PostgreSQL instead of in-memory database
   # jpa:
   #   database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+workflow:
+  bpmn-path: src/main/resources/processes/hello-user.bpmn20.xml


### PR DESCRIPTION
## Summary
- allow BPMN file path to come from `workflow.bpmn-path` and load via `FileInputStream`
- document reload behaviour in README
- set default `workflow.bpmn-path` in `application.yml`

## Testing
- `gradle test` *(fails: plugin org.springframework.boot could not be resolved)*